### PR TITLE
Differentiate between DSI-CAPE and DSI-LI

### DIFF
--- a/GOESnoncmip.conf
+++ b/GOESnoncmip.conf
@@ -26,7 +26,7 @@
 [[handler]]
 type = "image"
 origin = "goes16"
-products = [ "sst", "lst", "dsi", "tpw" ]
+products = [ "sst", "lst", "dsi-cape", "dsi-li", "tpw" ]
 directory = "./goes16/non-cmip/{region:short|lower}/{product:short|lower}/{time:%Y-%m-%d}"
 filename = "GOES16_{region:short}_{product:short}_{time:%Y%m%dT%H%M%SZ}"
 format = "jpg"
@@ -89,7 +89,7 @@ json = false
   ]
 
   # CAPE Derived Stability Index (Joules/kg)
-  [handler.gradient.DSI]
+  [handler.gradient.DSI-CAPE]
   points = [
     { units = 0, color = "#543e20" },
     { units = 500, color = "#a58154" },


### PR DESCRIPTION
This PR makes these configs compatible with the goestools pull request [163](https://github.com/pietern/goestools/pull/163).

No gradient has been written for DSI-LI yet, so this handler saves the file without a gradient. CAPE files have the gradient as normal. We should probably sit on this PR until a gradient is written, and the above goestools pull request is merged.