### PR TITLE
Add DSI-LI Gradient

### DIFF
--- a/GOESnoncmip.conf
+++ b/GOESnoncmip.conf
@@ -109,6 +109,22 @@ json = false
     { units = 4980.9245, color = "#000000" }
   ]
 
+  # Lifted Index (K)
+  [handler.gradient.DSI-LI]
+  points = [
+      { units = -10, color = "#ff0000" },
+      { units = -7.15, color = "#770000" },
+      { units = -4.9, color = "#656a00" },
+      { units = -1.75, color = "#e6fc00" },
+      { units = 3.5, color = "#808cfd" },
+      { units = 6.35, color = "#3f4578" },
+      { units = 10.7, color = "#f7b68f" },
+      { units = 13.7, color = "#7f8a8f" },
+      { units = 16.4, color = "#3d2d0c" },
+      { units = 20, color = "#cdaf84" },
+      { units = 40, color = "#000000" }
+  ]
+
   # Total Precipitable Water (mm)
   [handler.gradient.TPW]
   points = [


### PR DESCRIPTION
Adds the gradient for DSI Lifted Index. Requires the update in goestools pull request [163](https://github.com/pietern/goestools/pull/163).

Uses the gradient from http://cimss.ssec.wisc.edu/goes/OCLOFactSheetPDFs/ABIQuickGuide_BaselineDerivedStabilityIndices.pdf

![Scale](https://github.com/creinemann/EMWIN-NON-CMIP-SCRIPTS-FOR-GOESTOOLS/assets/24253715/0c21428b-099d-4055-9a9b-f17677d90111)

![GOES16_FD_DSI-LI_20230703T015021Z](https://github.com/creinemann/EMWIN-NON-CMIP-SCRIPTS-FOR-GOESTOOLS/assets/24253715/c0c8ebfc-c4b2-4acb-95f1-31b6542a371b)