### PR TITLE
Fix RRQPE Gradient

### DIFF
--- a/GOESnoncmip.conf
+++ b/GOESnoncmip.conf
@@ -170,7 +170,8 @@ json = false
     { units = 53.34, color = "#ff00f8" },
     { units = 63.5, color = "#c168c6" },
     { units = 66.04, color = "#fcfcfc" },
-    { units = 100, color = "#ffffff" }
+    { units = 99.2279, color = "#ffffff" },
+    { units = 99.6186, color = "#000000" }
   ]
 
   # Cloud top Height (Degrees K)


### PR DESCRIPTION
Fix RRQPE gradient to work for files transmitting after July 1, 2023. Should work for old files as well.

_GOES16_FD_RRQPE_20230705T225021Z_
![GOES16_FD_RRQPE_20230705T225021Z](https://github.com/creinemann/EMWIN-NON-CMIP-SCRIPTS-FOR-GOESTOOLS/assets/24253715/7ec4bd5b-9bd4-4233-9be3-082d7a24ee08)
