### PR TITLE
Roll back to old RRQPE gradient

### DIFF
--- a/GOESnoncmip.conf
+++ b/GOESnoncmip.conf
@@ -170,8 +170,7 @@ json = false
     { units = 53.34, color = "#ff00f8" },
     { units = 63.5, color = "#c168c6" },
     { units = 66.04, color = "#fcfcfc" },
-    { units = 99.2279, color = "#ffffff" },
-    { units = 99.6186, color = "#000000" }
+    { units = 100, color = "#ffffff" }
   ]
 
   # Cloud top Height (Degrees K)


### PR DESCRIPTION
The old RRQPE gradient has worked for several months again; it looks like NOAA is going to keep the downlink configured this way.

Reverting the RRQPE gradient since, while the new one works for both downlink formats, it sometimes displays heavy rainfall as black. The old gradient does not do that.